### PR TITLE
chore: promote aspnet-quickstart-test to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-production/aspnet-quickstart-test/aspnet-quickstart-test-aspnet-quickstart-test-deploy.yaml
+++ b/config-root/namespaces/jx-production/aspnet-quickstart-test/aspnet-quickstart-test-aspnet-quickstart-test-deploy.yaml
@@ -1,0 +1,60 @@
+# Source: aspnet-quickstart-test/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aspnet-quickstart-test-aspnet-quickstart-test
+  labels:
+    draft: draft-app
+    chart: "aspnet-quickstart-test-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'aspnet-quickstart-test'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-production
+spec:
+  selector:
+    matchLabels:
+      app: aspnet-quickstart-test-aspnet-quickstart-test
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: aspnet-quickstart-test-aspnet-quickstart-test
+    spec:
+      serviceAccountName: aspnet-quickstart-test-aspnet-quickstart-test
+      containers:
+      - name: aspnet-quickstart-test
+        image: "gcr.io/driven-reef-369119/aspnet-quickstart-test:0.0.1"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: VERSION
+          value: 0.0.1
+        envFrom: null
+        ports:
+        - name: http
+          containerPort: 80
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 400m
+            memory: 256Mi
+          requests:
+            cpu: 200m
+            memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/aspnet-quickstart-test/aspnet-quickstart-test-aspnet-quickstart-test-sa.yaml
+++ b/config-root/namespaces/jx-production/aspnet-quickstart-test/aspnet-quickstart-test-aspnet-quickstart-test-sa.yaml
@@ -1,0 +1,10 @@
+# Source: aspnet-quickstart-test/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aspnet-quickstart-test-aspnet-quickstart-test
+  annotations:
+    meta.helm.sh/release-name: 'aspnet-quickstart-test'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/aspnet-quickstart-test/aspnet-quickstart-test-ingress.yaml
+++ b/config-root/namespaces/jx-production/aspnet-quickstart-test/aspnet-quickstart-test-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: aspnet-quickstart-test/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'aspnet-quickstart-test'
+  name: aspnet-quickstart-test
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: aspnet-quickstart-test
+            port:
+              number: 80
+    host: aspnet-quickstart-test-jx-production.34.28.222.10.nip.io

--- a/config-root/namespaces/jx-production/aspnet-quickstart-test/aspnet-quickstart-test-svc.yaml
+++ b/config-root/namespaces/jx-production/aspnet-quickstart-test/aspnet-quickstart-test-svc.yaml
@@ -1,0 +1,20 @@
+# Source: aspnet-quickstart-test/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: aspnet-quickstart-test
+  labels:
+    chart: "aspnet-quickstart-test-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'aspnet-quickstart-test'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: aspnet-quickstart-test-aspnet-quickstart-test

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-qdrw4-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-qdrw4-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-tfdmu
+  name: jx-verify-gc-jobs-qdrw4
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-a5ghn
+    app: jx-verify-gc-jobs-7oynn
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-v56i5-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-v56i5-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-b67y6
+  name: jx-verify-gc-jobs-v56i5
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-8criv-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-8criv-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-lhnb1
+  name: jx-verify-gc-jobs-8criv
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-uovoi-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-uovoi-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-ryop2
+  name: jx-verify-gc-jobs-uovoi
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-u312a
+    app: jx-verify-gc-jobs-rshrc
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,13 @@
 	      <td></td>
 	    </tr>
     <tr>
+	      <td>aspnet-quickstart-test</td>
+	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> aspnet-quickstart-test</td>
+	      <td>0.0.1</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='5'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -17,6 +17,19 @@
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-production/jx-verify
+  - apiVersion: v1
+    appVersion: 0.0.1
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2022-11-21T22:49:57Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2022-11-21T22:49:57Z"
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=driven-reef-369119&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fjenkins-x-cluster%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Faspnet-quickstart-test&dateRangeUnbound=both
+    name: aspnet-quickstart-test
+    releaseName: aspnet-quickstart-test
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.34.28.222.10.nip.io
+    resourcePath: config-root/namespaces/jx-production/aspnet-quickstart-test
+    version: 0.0.1
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
   releases:

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -18,5 +18,7 @@ releases:
   version: 0.0.1
   name: aspnet-quickstart-test
   namespace: jx-production
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -6,11 +6,17 @@ environments:
 repositories:
 - name: jxgh
   url: https://jenkins-x-charts.github.io/repo
+- name: dev
+  url: http://chartmuseum-jx.34.28.222.10.nip.io
 releases:
 - chart: jxgh/jx-verify
   name: jx-verify
   namespace: jx-production
   values:
   - jx-values.yaml
+- chart: dev/aspnet-quickstart-test
+  version: 0.0.1
+  name: aspnet-quickstart-test
+  namespace: jx-production
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote aspnet-quickstart-test to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
